### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shamansir/js-aruco.git"
+    "url": "git+https://github.com/jcmellado/js-aruco.git"
   },
   "keywords": [
     "aruco",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "js-aruco",
+  "version": "1.0.0",
+  "description": "JavaScript library for Augmented Reality applications",
+  "main": "src/aruco.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shamansir/js-aruco.git"
+  },
+  "keywords": [
+    "aruco",
+    "cv"
+  ],
+  "author": "Juan Mellado",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jcmellado/js-aruco/issues"
+  },
+  "homepage": " http://www.uco.es/investiga/grupos/ava/node/26"
+}


### PR DESCRIPTION
Seems a number of [those who forked the repo](https://github.com/jcmellado/js-aruco/network), they did it just to add a `package.json`. In my case it's only to be able to install everything with one command, not to use it at server-side. This library is quite useful, so I think it really needs this file.